### PR TITLE
Replaces spaces with tabs, for accessibility

### DIFF
--- a/ScreensaverWatch/watch_screensaver.py
+++ b/ScreensaverWatch/watch_screensaver.py
@@ -22,13 +22,13 @@ def signal_handler(*args, **kwargs):
 		sys.stdout.flush()
 		url = f"{base}/services/input_boolean/turn_off"
 		response = post(url, headers=headers, json=data)
-        if (response.status_code == 200):
+		if (response.status_code == 200):
 			print("screensaverwatch: Set presence toggle to 'Off'")
 	else:
 		sys.stdout.flush()
 		url = f"{base}/services/input_boolean/turn_on"
 		response = post(url, headers=headers, json=data)
-        if (response.status_code == 200):
+		if (response.status_code == 200):
 			print("screensaverwatch: Set presence toggle to 'On'")
 
 def main():


### PR DESCRIPTION
My gvim is set up to convert tabs to spaces for those benighted projects slavishly following PEP 8's ableist "4 spaces" indentation. Where I have a choice, I will always use tabs over spaces, because they allow users to choose how much indentation they prefer visually, and are actually usable by those using screen readers, rather than having to keep count of space, space, space, space, space, space, space, ...